### PR TITLE
Add basic permissions so the plugin can be hidden for clients/users

### DIFF
--- a/controllers/ApiGeneratorController.php
+++ b/controllers/ApiGeneratorController.php
@@ -20,6 +20,7 @@ class ApiGeneratorController extends Controller
     protected $path         = "/api/";
     private $homePage       = 'ahmadfatoni/apigenerator/apigeneratorcontroller';
     protected $files;
+    public $requiredPermissions = ['ahmadfatoni.apigenerator.manage'];
 
     public function __construct(Filesystem $files)
     {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -9,3 +9,9 @@ navigation:
         label: 'API Generator'
         url: ahmadfatoni/apigenerator/apigeneratorcontroller
         icon: icon-cogs
+        permissions:
+            - ahmadfatoni.apigenerator.manage
+permissions:
+    ahmadfatoni.apigenerator.manage:
+        tab: 'API Generator'
+        label: 'Manage the API Generator'


### PR DESCRIPTION
I've been using this to add api endpoints to a clients site and noticed there were no permissions to stop them accessing the plugin and potentially breaking them. I've added a basic "manage" permission to allow the plugin to be hidden.